### PR TITLE
Metadata refactoring

### DIFF
--- a/js/htmlRenderer.js
+++ b/js/htmlRenderer.js
@@ -21,8 +21,13 @@ const htmlElement = (element) => ({
   attributes
 });
 
-// export const time = htmlElement("time")
-export const time = ({datetime, ...rest}) => htmlElement("time")({...rest, attributes: {...rest.attributes, datetime: datetime}});
+export const time = ({ datetime, ...rest }) => htmlElement("time")({
+  ...rest,
+  attributes: {
+    ...rest.attributes,
+    datetime: datetime
+  }
+});
 export const span = htmlElement("span");
 export const header = htmlElement("header");
 export const div = htmlElement("div");
@@ -36,37 +41,47 @@ export const ol = htmlElement("ol");
 export const li = htmlElement("li");
 
 export const render = (target, { element, id, className, children, innerHTML, attributes }) => {
-  // clearElements(target);
-  // TODO: think about how to use clearElement to remove only the elements that we want
-  // Try grabbing the document to create a diff, and only render the element if it doesn't exist already
-  // See how this is done in React
+  // TODO:
+  // Think about how to use clearElement to remove only the elements that
+  // we want Try grabbing the document to create a diff, and only render the
+  // element if it doesn't exist already ---> See how this is done in React
+  //
+  // ---> See how this is done in React
 
-  const el = document.createElement(element);
-  const attributeKeys = Object.keys(attributes);
-
-  if (attributeKeys.length > 0) {
-    attributeKeys.forEach(key => {
-      el.setAttribute(key, attributes[key])
-    });
-  };
-
-  if (innerHTML) {
-    el.innerHTML = innerHTML;
-  } else if (children.length > 0) {
+ // Uses the (never rendered) className `do-not-render` to indicate that only
+ // the children should be rendered and the containing div thrown away.
+  if (className == "do-not-render") {
     children.forEach(child => {
-      el.appendChild(render(el, child));
+      target.appendChild(render(target, child));
     })
+  } else {
+    const el = document.createElement(element);
+    const attributeKeys = Object.keys(attributes);
+
+    if (attributeKeys.length > 0) {
+      attributeKeys.forEach(key => {
+        el.setAttribute(key, attributes[key])
+      });
+    };
+
+    if (innerHTML) {
+      el.innerHTML = innerHTML;
+    } else if (children.length > 0) {
+      children.forEach(child => {
+        el.appendChild(render(el, child));
+      })
+    };
+
+    if (id != "") {
+      el.id = id;
+    }
+
+    if (className != "") {
+      el.className = className;
+    }
+
+    target.appendChild(el);
+
+    return el
   };
-
-  if (id != "") {
-    el.id = id;
-  }
-
-  if (className != "") {
-    el.className = className;
-  }
-
-  target.appendChild(el);
-
-  return el
 };

--- a/js/recipe/metadata.js
+++ b/js/recipe/metadata.js
@@ -13,19 +13,11 @@ export function metadata({ tags, name, datePublished, recipeYield }) {
   const metaChildren = [
     els.time({
       innerHTML: date,
-      datetime: "2020-12-16T09:09:00+00:00",
-      attributes: null
+      datetime: "2020-12-16T09:09:00+00:00"
     }),
     els.span({
       className: "tags",
-      innerHTML: "/ Tags: &nbsp"
-    }),
-    els.span({
-      children: [
-        els.span({
-          children: tagElements
-        })
-      ]
+      innerHTML: `Tags: ${tags.join(", ")}`
     }),
     els.span({
       className: "category",

--- a/js/recipe/metadata.js
+++ b/js/recipe/metadata.js
@@ -3,10 +3,6 @@ import { render } from "../htmlRenderer.js"
 import * as els from "../htmlRenderer.js"
 
 export function metadata({ tags, name, datePublished, recipeYield }) {
-  render(recipeParentElement, els.h1({className: "post-title", innerHTML: name}));
-  // TODO: Instead of passing siblings in as an extra argument, we could just create a containing div and render just that.
-  // Think about how we would tell `render` to render the children but not the parent element itself.
-
   const date = new Date(datePublished).toDateString();
   const tagElements = tags.map(tag => els.span({innerHTML: `${tag},&nbsp`})); // TODO: remove last comma
 
@@ -25,5 +21,17 @@ export function metadata({ tags, name, datePublished, recipeYield }) {
     })
   ];
 
-  render(recipeParentElement, els.div({className: "post-meta clear", children: metaChildren}));
+  return els.div({
+    className: "do-not-render",
+    children: [
+      els.h1({
+        className: "post-title",
+        innerHTML: name
+      }),
+      els.div({
+        className: "post-meta clear",
+        children: metaChildren
+      })
+    ]
+  });
 };

--- a/js/recipe/recipe.js
+++ b/js/recipe/recipe.js
@@ -19,7 +19,7 @@ let current_recipe = recipe();
 current_recipe.published = true; // recipe is published by default
 
 function displayRecipe(recipe) {
-  metadata(recipe);
+  render(recipeParentElement, metadata(recipe));
   render(recipeParentElement, image(recipe));
   render(recipeParentElement, introduction(recipe));
   render(recipeParentElement, ingredients(recipe));

--- a/style.css
+++ b/style.css
@@ -1,6 +1,26 @@
+.first-paragraph {
+  padding: 20px 0 0 0;
+}
+
+.introduction-paragraphs p {
+  padding: 0 0 20px 0;
+  margin: 0 10px 0 10px;
+}
+
+hr { margin: 20px 10px 20px 10px; }
+
 * {
   box-sizing: border-box;
   -moz-box-sizing: border-box;
+}
+
+#ingredients-list {
+  padding-bottom: 20px;
+  margin: 0 10px 0 30px;
+}
+
+.method-step {
+  margin: 20px 10px 0 30px;
 }
 
 body {


### PR DESCRIPTION
The metadata module now creates a containing div and wraps the title and meta-details elements within it, meaning that the metadata function can call `render` just once, like the other modules. Or, as is the case now, we are actually just returning an object with all the required data to create the element and its children, and letting recipe.js do the actual rendering.

The class name `do-not-render` has been used to tell `render` that the containing div should not be rendered itself but just its children.

Also, some styles added to make the recipe page look a bit prettier – you can ignore updates to that file :)